### PR TITLE
Windows testing-related changes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,7 +42,7 @@ browserify-test # run tests for ./test/*.js
 browserify-test --watch # start watch server on localhost:7537
 browserify-test ./path/to/test.js ./path/to/another-test.js # pass test files as arguments
 browserify-test ./lib/**/test.js # use globs
-browserify-test --tranform [ babelify --presets es2015 ] ./path/to/es6-test.js # use transforms
+browserify-test --transform [ babelify --presets es2015 ] ./path/to/es6-test.js # use transforms
 ```
 
 ## Integration with npm

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "test": "npm run prepublish && eslint src/ test/ && mocha",
-    "prepublish": "babel src --out-dir lib --presets es2015 && chmod 755 lib/cli.js"
+    "prepublish": "babel src --out-dir lib --presets es2015"
   },
   "dependencies": {
     "browserify": "^13.1.0",
@@ -42,8 +42,10 @@
     "babelify": "^7.3.0",
     "browserify-handlebars": "^1.0.0",
     "chai": "^3.5.0",
-    "eslint": "^2.13.1",
+    "eslint": "^3.0.0",
     "eslint-config-standard": "^5.3.5",
+    "eslint-plugin-promise": "^3.4.2",
+    "eslint-plugin-standard": "^2.0.1",
     "handlebars": "^4.0.5",
     "mocha": "^3.0.2"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,7 @@ describe('browserify-test', () => {
   })
 
   it('runs one file', (done) => {
-    exec('./lib/cli.js -t [ babelify --presets es2015 ] ./test/app/test/sum.js', (err, stdout) => {
+    exec('node ./lib/cli.js -t [ babelify --presets es2015 ] ./test/app/test/sum.js', (err, stdout) => {
       if (err) return done(err)
       expect(stdout).contain('test-sum calculates the sum')
       expect(stdout).contain('1..1')
@@ -23,7 +23,7 @@ describe('browserify-test', () => {
   })
 
   it('runs multiple files', (done) => {
-    exec('./lib/cli.js --transform [ babelify --presets es2015 ] ./test/app/test/sum.js ./test/app/test/odd.js', (err, stdout) => {
+    exec('node ./lib/cli.js --transform [ babelify --presets es2015 ] ./test/app/test/sum.js ./test/app/test/odd.js', (err, stdout) => {
       if (err) return done(err)
       expect(stdout).contain('1..2')
       expect(stdout).contain('# ok')
@@ -32,7 +32,7 @@ describe('browserify-test', () => {
   })
 
   it('supports globs', (done) => {
-    exec('./lib/cli.js -t [ babelify --presets es2015 ] ./test/app/test/*.js', (err, stdout) => {
+    exec('node ./lib/cli.js -t [ babelify --presets es2015 ] ./test/app/test/*.js', (err, stdout) => {
       if (err) return done(err)
       expect(stdout).contain('test-mul calculates the mul')
       expect(stdout).contain('test-mul supports many arguments')
@@ -45,7 +45,7 @@ describe('browserify-test', () => {
   })
 
   it('supports multiple transforms', (done) => {
-    exec('./lib/cli.js -t browserify-handlebars -t [ babelify --presets es2015 ] ./test/app/test2/read-html.js', (err, stdout) => {
+    exec('node ./lib/cli.js -t browserify-handlebars -t [ babelify --presets es2015 ] ./test/app/test2/read-html.js', (err, stdout) => {
       if (err) return done(err)
       expect(stdout).contain('test-read-file reads index.html')
       expect(stdout).contain('1..1')
@@ -55,7 +55,7 @@ describe('browserify-test', () => {
   })
 
   it('supports --watch', (done) => {
-    child = spawn('./lib/cli.js', ['--transform', '[', 'babelify', '--presets', 'es2015', ']', '-w', './test/app/test/mul.js'])
+    child = spawn('node', ['./lib/cli.js', '--transform', '[', 'babelify', '--presets', 'es2015', ']', '-w', './test/app/test/mul.js'])
     let counter = 0
 
     child.stdout.on('data', (data) => {


### PR DESCRIPTION
- npm: Add eslint-plugins for non-global inclusion during testing
- npm: Bump ESLint major version (notices during `npm install`)
- npm: Avoid the chmod; trips up Windows and handled by `bin`
- Testing: Prefix exec/spawn paths with Windows-friendly `node`
- Docs: Fix README typo
- ~Fix: Have .gitignore to allow `lib` and add; otherwise, install
   of package.json (which occurs by default without `prepublish` or
   a babel install unless running a local install (in npm < 5) of
   browserify-test) looking for the directory complains that
   script is not found; an `install` script would need to add
   `babel` as a regular dependency~