### PR TITLE
Browserify customizability enhancements

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,6 +37,8 @@ browserify-test --help
     -V, --version               output the version number
     -w, --watch                 run watch server on http://localhost:7357
     -t, --transform <t1,t2,..>  add browserify transforms
+    -p, --plugins <p1,p2,..>    add browserify plugins
+    -b, --browserifyOptions <jsonStringifiedObj> add browserifyOptions
 
 browserify-test # run tests for ./test/*.js
 browserify-test --watch # start watch server on localhost:7537
@@ -87,9 +89,11 @@ run({
 
 Options:
 
+* `files` - Array - a list of files for browserify
 * `watch` - Boolean - enable watch server
 * `transform` - Array - a list of browserify transform modules
-* `files` - Array - a list of files for browserify
+* `plugins` - Array - a list of browserify transform modules
+* `browserifyOptions` - Object - options to pass to `browserify`
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "lodash.omit": "^4.4.1",
     "subarg": "^1.0.0",
     "testem": "^1.10.3",
-    "watchify": "^3.7.0"
+    "watchify": "^3.7.0",
+    "phantomjs-prebuilt": "^2.1.14"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",

--- a/test/odd-noES6.js
+++ b/test/odd-noES6.js
@@ -1,0 +1,12 @@
+/* eslint-env mocha */
+var expect = require('chai').expect
+function odd () {
+  return [].slice.call(arguments).reduce(function (memo, val) { memo -= val; return memo })
+}
+
+describe('test-odd', function () {
+  it('calculates the odd', function () {
+    expect(odd(10, 20)).equal(-10)
+    expect(odd(10, -20)).equal(30)
+  })
+})


### PR DESCRIPTION
- Enhancement: Support `plugins` array (strings, functions, or arrays) in CLI/Node
- Enhancement: `transforms` alias for `transform` to parallel
     `plugins` plural
- Enhancement: Add `entries` alias to parallel `browserify`
- Enhancement: Support custom options to `browserify`
- Enhancement: Return `browserify` instance to support further
    pipelining, etc.
- Enhancement: Support testem options
- Enhancement: Support finalizer function
- Enhancement: Support transform functions
- Fix: Ensure proper testem method is called on watch updates
- Testing: Ensure phantomjs-prebuilt is installed
- Testing: Add tests for missing `files`, not throwing without transforms

Addresses issue #4